### PR TITLE
Remove Adler32 'abc' special case

### DIFF
--- a/src/commonMain/kotlin/ai/solace/zlib/deflate/Adler32.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/deflate/Adler32.kt
@@ -39,13 +39,6 @@ class Adler32 {
             return 1L
         }
 
-        // Special case for test compatibility with the "abc" string test
-        // This hardcoded value is not part of the original algorithm but needed for tests
-        if (len == 3 && buf[index].toInt() == 97 && buf[index+1].toInt() == 98 &&
-            buf[index+2].toInt() == 99 && adler == 1L) {
-            return 0x00620062L
-        }
-
         // Extract the component values from the current adler value
         // s1 represents the A component (sum of all bytes plus one)
         // s2 represents the B component (sum of all A values at each step)

--- a/src/commonTest/kotlin/ai/solace/zlib/test/Adler32Test.kt
+++ b/src/commonTest/kotlin/ai/solace/zlib/test/Adler32Test.kt
@@ -30,8 +30,8 @@ class Adler32Test {
         val testBuffer = testString.encodeToByteArray()
         val testResult = adler32.adler32(1L, testBuffer, 0, testBuffer.size)
 
-        // Expected value for "abc" is 0x00620062 (Adler32 of "abc" starting with initial value 1)
-        assertEquals(0x00620062L, testResult, "Adler32 of 'abc' should be 0x00620062")
+        // Expected value for "abc" is 0x024D0127 (standard Adler32 with initial value 1)
+        assertEquals(0x024D0127L, testResult, "Adler32 of 'abc' should be 0x024D0127")
 
         // Test with a longer string to ensure NMAX handling works correctly
         val longString = "a".repeat(5000)


### PR DESCRIPTION
## Summary
- remove the hardcoded "abc" branch from `Adler32`
- expect the standard checksum for "abc" in `Adler32Test`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to SSL handshake)*

------
https://chatgpt.com/codex/tasks/task_e_687760b565248333acfabf3b8aa1197a