### PR TITLE
Add multiplatform test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Usage](#usage)
 - [Documentation](#documentation)
 - [Compatibility](#compatibility)
+- [Testing](#testing)
 - [Credits & Lineage](#credits--lineage)
 - [License](#license)
 - [Contributing](#contributing)
@@ -120,6 +121,21 @@ Practical examples demonstrating:
 - **Kotlin Multiplatform:** Experimental support for JS and other targets
 
 Tested with IntelliJ IDEA and Gradle.
+
+---
+
+## Testing
+
+Run the multiplatform tests using Gradle. For example, to execute the Linux x64
+tests run:
+
+```bash
+./gradlew linuxX64Test
+```
+
+Additional targets, such as the JVM, have their own `<target>Test` task
+(e.g., `./gradlew jvmTest`). macOS target tasks may be disabled when running on a
+non-macOS host.
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to run multiplatform test tasks

## Testing
- `gradle linuxX64Test --dry-run` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_687762e4ee848333aaa974a37593325e