### PR TITLE
Fix Adler32 checksum and compression header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,12 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
-    
+
+    // Add JVM target so tests can run without downloading native toolchains
+    jvm {
+        withJava()
+    }
+
     // Only include Linux x64 for now to avoid network dependency issues
     linuxX64 {
         binaries {
@@ -52,6 +57,14 @@ kotlin {
             dependsOn(commonMain)
         }
         val nativeTest by creating {
+            dependsOn(commonTest)
+        }
+
+        // JVM source sets
+        val jvmMain by getting {
+            dependsOn(commonMain)
+        }
+        val jvmTest by getting {
             dependsOn(commonTest)
         }
 

--- a/src/commonMain/kotlin/ai/solace/zlib/bitwise/checksum/Adler32Utils.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/bitwise/checksum/Adler32Utils.kt
@@ -50,7 +50,7 @@ class Adler32Utils {
                 b %= ADLER_BASE
             }
 
-            return (b shl 16) or (a and 0xFFFF)
+            return ((b and 0xFFFF) shl 16) or (a and 0xFFFF)
         }
     }
 }

--- a/src/commonMain/kotlin/ai/solace/zlib/bitwise/checksum/Adler32Utils.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/bitwise/checksum/Adler32Utils.kt
@@ -1,105 +1,56 @@
 package ai.solace.zlib.bitwise.checksum
 
 import ai.solace.zlib.bitwise.BitwiseOps
-import ai.solace.zlib.bitwise.BitShiftEngine
-import ai.solace.zlib.bitwise.BitShiftMode
 import ai.solace.zlib.common.ADLER_BASE
 import ai.solace.zlib.common.ADLER_NMAX
 
 /**
- * Adler32 checksum implementation using configurable bit shift operations.
- * 
- * This implementation can use either:
- * - Native Kotlin bitwise operations (fast, but may have platform differences)
- * - Arithmetic-only operations (slower, but fully consistent across platforms)
- * 
- * The choice is made through the BitShiftEngine configuration.
- * 
- * Algorithm:
- * - Data is processed in chunks of ADLER_NMAX bytes to prevent integer overflow
- * - For each chunk: a = sum of bytes (mod 65521), b = sum of running sums (mod 65521)
- * - Final checksum: b * 65536 + a
- * 
- * This implementation follows the standard Adler-32 algorithm specification.
+ * Adler32 checksum implementation using plain arithmetic operations.
+ *
+ * The algorithm processes the input in chunks of [ADLER_NMAX] bytes to avoid
+ * integer overflow. For each chunk it accumulates two sums:
+ *  - **a**: the sum of all bytes
+ *  - **b**: the sum of running values of a
+ *
+ * The final checksum is `(b shl 16) or a` where both a and b are computed
+ * modulo [ADLER_BASE].
+ *
+ * This simplified version avoids the previous bit-shift engine abstraction
+ * which produced incorrect results on some platforms.
  */
 class Adler32Utils {
     companion object {
-        
-        // Default engine uses native operations for better performance
-        private val defaultEngine = BitShiftEngine(BitShiftMode.NATIVE, 32)
-        
+
         /**
-         * Calculates or updates an Adler-32 checksum using the default bit shift engine
+         * Calculates or updates an Adler-32 checksum.
+         *
          * @param adler Initial checksum value (use 1 for new checksums)
-         * @param buf Data buffer to calculate checksum for
+         * @param buf   Data buffer to calculate checksum for
          * @param index Starting index in the buffer
-         * @param len Number of bytes to process
+         * @param len   Number of bytes to process
          * @return Updated Adler-32 checksum
          */
         fun adler32(adler: Long, buf: ByteArray?, index: Int, len: Int): Long {
-            return adler32(adler, buf, index, len, defaultEngine)
-        }
-        
-        /**
-         * Calculates or updates an Adler-32 checksum using the specified bit shift engine
-         * @param adler Initial checksum value (use 1 for new checksums)
-         * @param buf Data buffer to calculate checksum for
-         * @param index Starting index in the buffer
-         * @param len Number of bytes to process
-         * @param engine BitShiftEngine to use for bit operations
-         * @return Updated Adler-32 checksum
-         */
-        fun adler32(adler: Long, buf: ByteArray?, index: Int, len: Int, engine: BitShiftEngine): Long {
             if (buf == null) return 1L
 
-            val MOD = ADLER_BASE
-            
-            // Extract a and b from the input adler value using the engine
-            val highExtracted = engine.unsignedRightShift(adler, 16)
-            var a = (adler and 0xFFFF).toInt()
-            var b = highExtracted.value.toInt()
+            var a = (adler and 0xFFFF).toLong()
+            var b = ((adler ushr 16) and 0xFFFF)
 
             var i = index
             val end = index + len
-            
-            // Process data in chunks of ADLER_NMAX to prevent overflow
+
             while (i < end) {
                 val chunkEnd = minOf(i + ADLER_NMAX, end)
-                
-                // Process bytes in current chunk without modulo
                 while (i < chunkEnd) {
-                    val unsigned = BitwiseOps.byteToUnsignedInt(buf[i])
-                    a += unsigned
+                    a += BitwiseOps.byteToUnsignedInt(buf[i])
                     b += a
                     i++
                 }
-                
-                // Apply modulo only after processing the chunk
-                a %= MOD
-                b %= MOD
+                a %= ADLER_BASE
+                b %= ADLER_BASE
             }
 
-            // Combine a and b into the final result using the engine
-            val bShifted = engine.leftShift(b.toLong(), 16)
-            return bShifted.value or (a.toLong() and 0xFFFF)
-        }
-        
-        /**
-         * Creates an Adler32Utils instance that uses arithmetic operations for full cross-platform consistency
-         * @return Configured utility function
-         */
-        fun withArithmeticEngine(): (Long, ByteArray?, Int, Int) -> Long {
-            val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-            return { adler, buf, index, len -> adler32(adler, buf, index, len, arithmeticEngine) }
-        }
-        
-        /**
-         * Creates an Adler32Utils instance that uses native operations for best performance
-         * @return Configured utility function
-         */
-        fun withNativeEngine(): (Long, ByteArray?, Int, Int) -> Long {
-            val nativeEngine = BitShiftEngine(BitShiftMode.NATIVE, 32)
-            return { adler, buf, index, len -> adler32(adler, buf, index, len, nativeEngine) }
+            return (b shl 16) or (a and 0xFFFF)
         }
     }
 }

--- a/src/commonMain/kotlin/ai/solace/zlib/deflate/Deflate.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/deflate/Deflate.kt
@@ -840,8 +840,12 @@ class Deflate {
         lastFlush = flush
         if (status == INIT_STATE) {
             var header: Int = (Z_DEFLATED + ((wBits - 8) shl 4)) shl 8
-            var levelFlagsLocal: Int = ((this.level - 1) and 0xff) shr 1
-            if (levelFlagsLocal > 3) levelFlagsLocal = 3
+            val levelFlagsLocal = when {
+                this.level <= 0 -> 0
+                this.level in 1..3 -> 1
+                this.level in 4..6 -> 2
+                else -> 3
+            }
             header = header or (levelFlagsLocal shl 6)
             if (strStart != 0) header = header or PRESET_DICT
             header += 31 - (header % 31)

--- a/src/commonMain/kotlin/ai/solace/zlib/deflate/Inflate.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/deflate/Inflate.kt
@@ -335,7 +335,10 @@ internal class Inflate {
                     }
                     ZlibLogger.logInflate("Blocks processing complete! Transitioning to checksum verification")
                     r = fMut
-                    z.iState!!.blocks!!.reset(z, z.iState!!.was)
+                    // Capture computed checksum before resetting blocks, as reset() clears z.adler
+                    val computedCheck = z.adler
+                    z.iState!!.blocks!!.reset(z, null)
+                    z.iState!!.was[0] = computedCheck
                     if (z.iState!!.nowrap != 0) {
                         ZlibLogger.logInflate("Raw deflate mode (nowrap=${z.iState!!.nowrap}), going to INF_DONE")
                         z.iState!!.mode = INF_DONE

--- a/src/commonTest/kotlin/ai/solace/zlib/bitwise/test/Adler32EngineTest.kt
+++ b/src/commonTest/kotlin/ai/solace/zlib/bitwise/test/Adler32EngineTest.kt
@@ -1,139 +1,51 @@
 package ai.solace.zlib.bitwise.test
 
 import ai.solace.zlib.bitwise.checksum.Adler32Utils
-import ai.solace.zlib.bitwise.BitShiftEngine
-import ai.solace.zlib.bitwise.BitShiftMode
 import kotlin.test.*
 
-/**
- * Test that validates Adler32 works correctly with both arithmetic and native bit shift engines
- */
 class Adler32EngineTest {
-    
-    @Test
-    fun testAdler32ConsistencyBetweenEngines() {
-        val testData = "Hello, World! This is a test string for Adler32 checksum calculation.".encodeToByteArray()
-        
-        // Calculate using default (native) engine
-        val nativeResult = Adler32Utils.adler32(1L, testData, 0, testData.size)
-        
-        // Calculate using arithmetic engine
-        val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-        val arithmeticResult = Adler32Utils.adler32(1L, testData, 0, testData.size, arithmeticEngine)
-        
-        assertEquals(nativeResult, arithmeticResult,
-            "Adler32 results should be identical between native and arithmetic engines")
-    }
-    
-    @Test
-    fun testAdler32WithFactoryFunctions() {
-        val testData = "Factory function test".encodeToByteArray()
-        
-        val nativeFunction = Adler32Utils.withNativeEngine()
-        val arithmeticFunction = Adler32Utils.withArithmeticEngine()
-        
-        val nativeResult = nativeFunction(1L, testData, 0, testData.size)
-        val arithmeticResult = arithmeticFunction(1L, testData, 0, testData.size)
-        
-        assertEquals(nativeResult, arithmeticResult,
-            "Factory function results should be identical")
-    }
-    
     @Test
     fun testAdler32KnownValues() {
-        // Test with known values to ensure correctness
         val testCases = listOf(
-            Pair("", 0x00000001L),  // Empty string should return 1
-            Pair("a", 0x00620062L), // Single character
-            Pair("abc", 0x024d0127L), // Short string
-            Pair("message digest", 0x29750586L), // Medium string
+            "" to 0x00000001L,
+            "a" to 0x00620062L,
+            "abc" to 0x024d0127L,
+            "message digest" to 0x29750586L,
         )
-        
-        val nativeEngine = BitShiftEngine(BitShiftMode.NATIVE, 32)
-        val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-        
         for ((input, expected) in testCases) {
             val data = input.encodeToByteArray()
-            
-            val nativeResult = Adler32Utils.adler32(1L, data, 0, data.size, nativeEngine)
-            val arithmeticResult = Adler32Utils.adler32(1L, data, 0, data.size, arithmeticEngine)
-            
-            assertEquals(expected, nativeResult, "Native engine failed for input: '$input'")
-            assertEquals(expected, arithmeticResult, "Arithmetic engine failed for input: '$input'")
+            val result = Adler32Utils.adler32(1L, data, 0, data.size)
+            assertEquals(expected, result, "Adler32 failed for input: '$input'")
         }
     }
-    
+
     @Test
     fun testAdler32Incremental() {
         val fullData = "This is a long test string that we will process incrementally".encodeToByteArray()
-        
-        // Calculate in one go
         val fullResult = Adler32Utils.adler32(1L, fullData, 0, fullData.size)
-        
-        // Calculate incrementally using arithmetic engine
-        val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-        var incrementalResult = 1L
+        var incremental = 1L
         val chunkSize = 10
-        
         var offset = 0
         while (offset < fullData.size) {
             val len = minOf(chunkSize, fullData.size - offset)
-            incrementalResult = Adler32Utils.adler32(incrementalResult, fullData, offset, len, arithmeticEngine)
+            incremental = Adler32Utils.adler32(incremental, fullData, offset, len)
             offset += len
         }
-        
-        assertEquals(fullResult, incrementalResult,
-            "Incremental calculation should match full calculation")
+        assertEquals(fullResult, incremental, "Incremental calculation should match full calculation")
     }
-    
+
     @Test
     fun testAdler32EdgeCases() {
-        val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-        
-        // Test null buffer
-        val nullResult = Adler32Utils.adler32(1L, null, 0, 0, arithmeticEngine)
+        val nullResult = Adler32Utils.adler32(1L, null, 0, 0)
         assertEquals(1L, nullResult, "Null buffer should return 1")
-        
-        // Test empty buffer
+
         val emptyData = ByteArray(0)
-        val emptyResult = Adler32Utils.adler32(1L, emptyData, 0, 0, arithmeticEngine)
+        val emptyResult = Adler32Utils.adler32(1L, emptyData, 0, 0)
         assertEquals(1L, emptyResult, "Empty buffer should return 1")
-        
-        // Test large values (ensure no overflow issues)
+
         val largeInitial = 0x7FFFFFFFL
-        val testData = ByteArray(1000) { it.toByte() }
-        val largeResult = Adler32Utils.adler32(largeInitial, testData, 0, testData.size, arithmeticEngine)
-        
+        val data = ByteArray(1000) { it.toByte() }
+        val largeResult = Adler32Utils.adler32(largeInitial, data, 0, data.size)
         assertTrue(largeResult > 0, "Result should be positive even with large initial value")
-    }
-    
-    @Test
-    fun testBitShiftEngineConsistency() {
-        // Test that the bit operations used in Adler32 work consistently
-        val testValue = 0x12345678L
-        
-        val nativeEngine = BitShiftEngine(BitShiftMode.NATIVE, 32)
-        val arithmeticEngine = BitShiftEngine(BitShiftMode.ARITHMETIC, 32)
-        
-        // Test left shift by 16 (used in Adler32 to combine high/low parts)
-        val nativeShift = nativeEngine.leftShift(testValue and 0xFFFF, 16)
-        val arithmeticShift = arithmeticEngine.leftShift(testValue and 0xFFFF, 16)
-        
-        assertEquals(nativeShift.value, arithmeticShift.value,
-            "16-bit left shift should be consistent between engines")
-        
-        // Test right shift by 16 (used in Adler32 to extract high part)
-        val nativeRight = nativeEngine.unsignedRightShift(testValue, 16)
-        val arithmeticRight = arithmeticEngine.unsignedRightShift(testValue, 16)
-        
-        assertEquals(nativeRight.value, arithmeticRight.value,
-            "16-bit right shift should be consistent between engines")
-        
-        // Test that we can round-trip a value
-        val high = (testValue ushr 16) and 0xFFFF
-        val low = testValue and 0xFFFF
-        val recombined = nativeEngine.leftShift(high, 16).value or low
-        
-        assertEquals(testValue, recombined, "Should be able to round-trip a 32-bit value")
     }
 }

--- a/src/jvmMain/kotlin/ai/solace/zlib/cli/FileOperations.jvm.kt
+++ b/src/jvmMain/kotlin/ai/solace/zlib/cli/FileOperations.jvm.kt
@@ -1,0 +1,9 @@
+package ai.solace.zlib.cli
+
+import java.io.File
+
+actual fun readFile(path: String): ByteArray = File(path).readBytes()
+
+actual fun writeFile(path: String, data: ByteArray) {
+    File(path).writeBytes(data)
+}

--- a/src/jvmMain/kotlin/ai/solace/zlib/common/ZlibLoggerJvm.kt
+++ b/src/jvmMain/kotlin/ai/solace/zlib/common/ZlibLoggerJvm.kt
@@ -1,0 +1,13 @@
+package ai.solace.zlib.common
+
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+actual fun logToFile(line: String) {
+    File("zlib.log").appendText(line)
+}
+
+actual fun currentTimestamp(): String {
+    return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+}

--- a/src/jvmMain/kotlin/ai/solace/zlib/streams/InputStream.jvm.kt
+++ b/src/jvmMain/kotlin/ai/solace/zlib/streams/InputStream.jvm.kt
@@ -1,0 +1,3 @@
+package ai.solace.zlib.streams
+
+actual typealias InputStream = java.io.InputStream


### PR DESCRIPTION
## Summary
- replace BitShift-based Adler32 with straightforward arithmetic implementation
- add JVM target with platform-specific utilities
- correct deflate header level flags and preserve inflate checksum during reset

## Testing
- `./gradlew jvmTest --tests "*Adler32*"`
- `./gradlew jvmTest --tests "*MulticharacterFixTest*"`
- `./gradlew jvmTest --tests "*DeflateCompressionLevelTest.testSingleCharacterWithNoCompression*"` *(fails: incorrect data check)*

------
https://chatgpt.com/codex/tasks/task_e_68b00094a7e083339f3bdb5e040cbb8a