### PR TITLE
Fix BitBuffer 32-bit consumption handling

### DIFF
--- a/src/commonMain/kotlin/ai/solace/zlib/bitwise/BitBuffer.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/bitwise/BitBuffer.kt
@@ -52,13 +52,17 @@ class BitBuffer {
         
         // Get the lowest N bits
         val result = buffer and BitwiseOps.createMask(bits)
-        
-        // Shift the buffer right by N bits, effectively removing the consumed bits
-        buffer = buffer ushr bits
-        
+
+        // Shift the buffer or clear it if consuming all bits
+        if (bits >= 32 || bitCount - bits == 0) {
+            buffer = 0
+        } else {
+            buffer = buffer ushr bits
+        }
+
         // Update the bit count
         bitCount -= bits
-        
+
         return result
     }
     

--- a/src/commonTest/kotlin/ai/solace/zlib/bitwise/test/BitBufferTest.kt
+++ b/src/commonTest/kotlin/ai/solace/zlib/bitwise/test/BitBufferTest.kt
@@ -89,6 +89,21 @@ class BitBufferTest {
         buffer.addByte(0x5A.toByte())
         assertFailsWith<IllegalArgumentException> { buffer.consumeBits(9) }
     }
+
+    @Test
+    fun testConsume32BitsClearsBuffer() {
+        val buffer = BitBuffer()
+
+        // Fill the buffer with 32 bits
+        repeat(4) { buffer.addByte(0xFF.toByte()) }
+        assertEquals(32, buffer.getBitCount())
+
+        // Consume all 32 bits and verify the buffer is cleared
+        val result = buffer.consumeBits(32)
+        assertEquals(-1, result)
+        assertEquals(0, buffer.getBitCount())
+        assertEquals(0, buffer.getBuffer())
+    }
     
     @Test
     fun testHasEnoughBits() {


### PR DESCRIPTION
## Summary
- ensure consuming 32 bits clears the internal buffer
- add test for consuming all 32 bits

## Testing
- `./gradlew jvmTest` *(fails: ImprovedBitShiftTest, DeflateCompressionLevelTest, HuffmanFixValidationTest, InflateTest, InflateWindowWrapTest)*
- `./gradlew jvmTest --tests "ai.solace.zlib.bitwise.test.BitBufferTest.testConsume32BitsClearsBuffer"`


------
https://chatgpt.com/codex/tasks/task_e_68b3e1611f08833393fc296517f6999e