### PR TITLE
Prevent infinite loop on truncated input

### DIFF
--- a/src/commonMain/kotlin/ai/solace/zlib/ZLibCompression.kt
+++ b/src/commonMain/kotlin/ai/solace/zlib/ZLibCompression.kt
@@ -114,6 +114,9 @@ class ZLibCompression {
 
                     // Add what we've already decompressed
                     val firstChunkSize = output.size - stream.availOut
+                    if (firstChunkSize == 0 && stream.availIn == 0) {
+                        throw ZStreamException("Truncated input: no progress during inflate")
+                    }
                     if (firstChunkSize > 0) {
                         chunks.add(output.copyOf(firstChunkSize))
                         totalSize += firstChunkSize
@@ -135,6 +138,9 @@ class ZLibCompression {
 
                         // Add this chunk to our list if it has any data
                         val chunkSize = nextBuffer.size - stream.availOut
+                        if (chunkSize == 0 && stream.availIn == 0) {
+                            throw ZStreamException("Truncated input: no progress during inflate")
+                        }
                         if (chunkSize > 0) {
                             chunks.add(nextBuffer.copyOf(chunkSize))
                             totalSize += chunkSize

--- a/src/commonTest/kotlin/ai/solace/zlib/test/TruncatedDataTest.kt
+++ b/src/commonTest/kotlin/ai/solace/zlib/test/TruncatedDataTest.kt
@@ -1,0 +1,19 @@
+package ai.solace.zlib.test
+
+import ai.solace.zlib.ZLibCompression
+import ai.solace.zlib.deflate.ZStreamException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class TruncatedDataTest {
+    @Test
+    fun truncatedInputThrowsException() {
+        val original = "Hello truncated".encodeToByteArray()
+        val compressed = ZLibCompression.compress(original)
+        val truncated = compressed.copyOf(compressed.size - 1)
+
+        assertFailsWith<ZStreamException> {
+            ZLibCompression.decompress(truncated)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect stalled inflate in `decompress` and throw `ZStreamException`
- test that truncated compressed data fails fast

## Testing
- `./gradlew jvmTest --tests ai.solace.zlib.test.TruncatedDataTest --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68b3e36a6ccc8333b927a43ea70685e8