### PR TITLE
Bump actions/checkout in codeql.yml to v6.0.2 (Node 24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` in `codeql.yml` from `@v4` to `@v6.0.2`. That's the only step on this repo's CI surface still resolving the Node 20-based release, which triggers the runtime deprecation warning:

```
##[warning]Node.js 20 actions are deprecated. The following actions are
running on Node.js 20 and may not work as expected: actions/checkout@v4.
Actions will be forced to run with Node.js 24 by default starting June
2nd, 2026.
```

`github/codeql-action/init@v4` and `analyze@v4` stay on `v4`: those major versions are current, and they don't surface the warning because the codeql-action's internal Node runtime is managed by GitHub independent of the surface pin.

## Scope

Single file, one-line diff. No build behavior change.
